### PR TITLE
Add ability for a random delay before restarting edging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ and is automatically generated. Here is a quick summary of config variables:
 |`motor_start_speed`|Byte|10|The minimum speed the motor will start at in automatic mode.|
 |`motor_max_speed`|Byte|128|Maximum speed for the motor in auto-ramp mode.|
 |`motor_ramp_time_s`|Int|30|The time it takes for the motor to reach `motor_max_speed` in auto ramp mode.|
-|`edge_delay`|Int|10000|Time (ms) after edge detection before resuming stimulation.|
+|`edge_delay`|Int|10000|Minimum time (ms) after edge detection before resuming stimulation.|
+|`max_additional_delay`|Int|10000|Maximum time (ms) that can be added to the edge delay before resuming stimulation. A random number will be picked between 0 and this setting each cycle. 0 to disable.|
 |`minimum_on_time`|Int|1000|Time (ms) after stimulation starts before edge detection is resumed.|
 |`screen_dim_seconds`|Int|10|Time, in seconds, before the screen dims. 0 to disable.|
 |`screen_timeout_seconds`|Int|0|Time, in seconds, before the screen turns off. 0 to disable.|

--- a/config.h
+++ b/config.h
@@ -102,6 +102,7 @@ struct ConfigStruct {
   byte motor_max_speed;
   byte motor_start_speed;
   int edge_delay;
+  int max_additional_delay;
   int minimum_on_time;
   byte pressure_smoothing;
   int sensitivity_threshold;

--- a/include/OrgasmControl.h
+++ b/include/OrgasmControl.h
@@ -53,6 +53,7 @@ namespace OrgasmControl {
     long motor_stop_time = 0;
     long motor_start_time = 0;
     long edge_time_out = 10000;
+    long random_additional_delay = 0;
     int twitch_count = 0;
 
 

--- a/src/OrgasmControl.cpp
+++ b/src/OrgasmControl.cpp
@@ -40,21 +40,26 @@ namespace OrgasmControl {
 
       bool time_out_over = false;
       long on_time = millis() - motor_start_time;
-      if (millis() - motor_stop_time > Config.edge_delay){
+      if (millis() - motor_stop_time > Config.edge_delay + random_additional_delay){
         time_out_over = true;
       }
       // Ope, orgasm incoming! Stop it!
       if (arousal > Config.sensitivity_threshold && motor_speed > 0 && on_time > Config.minimum_on_time) {
         // The motor_speed check above, btw, is so we only hit this once per peak.
-        // Set the motor speed to 0, and set stop time.
+        // Set the motor speed to 0, set stop time, and determine the new additional random time.
         motor_speed = 0;
         motor_stop_time = millis();
+        // If Max Additional Delay is not disabled, caculate a new delay every time the motor is stopped.
+        if (Config.max_additional_delay != 0) {
+          random_additional_delay = random(Config.max_additional_delay);
+        }
         denial_count++;
       } else if (!time_out_over) {
           twitchDetect();
       } else if (motor_speed == 0){
           motor_start_time = millis();
           motor_speed = Config.motor_start_speed;
+          random_additional_delay = 0;
       } else if (motor_speed < Config.motor_max_speed) {
           motor_speed += motor_increment;
       } else if (motor_speed > Config.motor_max_speed) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -93,6 +93,7 @@ void loadConfigFromJsonObject(JsonDocument &doc) {
   Config.motor_max_speed = doc["motor_max_speed"] | 128;
   Config.motor_start_speed = doc["motor_start_speed"] | 10;
   Config.edge_delay = doc["edge_delay"] | 10000;
+  Config.max_additional_delay = doc["max_additional_delay"] | 10000;
   Config.minimum_on_time = doc["minimum_on_time"] | 1000;
   Config.pressure_smoothing = doc["pressure_smoothing"] | 5;
   Config.sensitivity_threshold = doc["sensitivity_threshold"] | 600;
@@ -137,6 +138,7 @@ void dumpConfigToJsonObject(JsonDocument &doc) {
   doc["motor_max_speed"] = Config.motor_max_speed;
   doc["motor_start_speed"] = Config.motor_start_speed;
   doc["edge_delay"] = Config.edge_delay;
+  doc["max_additional_delay"] = Config.max_additional_delay;
   doc["minimum_on_time"] = Config.minimum_on_time;
   doc["pressure_smoothing"] = Config.pressure_smoothing;
   doc["sensitivity_threshold"] = Config.sensitivity_threshold;
@@ -224,6 +226,8 @@ bool setConfigValue(const char *option, const char *value, bool &require_reboot)
     Config.motor_start_speed = atoi(value);
   } else if(!strcmp(option, "edge_delay")) {
     Config.edge_delay = atoi(value);
+  } else if(!strcmp(option, "max_additional_delay")) {
+    Config.max_additional_delay = atoi(value);
   } else if(!strcmp(option, "minimum_on_time")) {
     Config.minimum_on_time = atoi(value);
   } else if(!strcmp(option, "screen_dim_seconds")) {
@@ -282,6 +286,8 @@ bool getConfigValue(const char *option, String &out) {
     out += String(Config.motor_start_speed) + '\n';
   } else if(!strcmp(option, "edge_delay")) {
     out += String(Config.edge_delay) + '\n';
+  } else if(!strcmp(option, "max_additional_delay")) {
+    out += String(Config.max_additional_delay) + '\n';
   } else if(!strcmp(option, "minimum_on_time")) {
     out += String(Config.minimum_on_time) + '\n';
   } else if(!strcmp(option, "screen_dim_seconds")) {

--- a/src/menus/EdgingSettingsMenu.cpp
+++ b/src/menus/EdgingSettingsMenu.cpp
@@ -67,6 +67,19 @@ UIInput EdgeDelayInput("Edge Delay", [](UIMenu *ip) {
   });
 });
 
+UIInput MaxAdditionalDelayInput("Maximum Additional Delay", [](UIMenu *ip) {
+  UIInput *input = (UIInput*) ip;
+  input->setMax(60);
+  input->setStep(1);
+  input->setValue(Config.max_additional_delay / 1000);
+  input->onChange([](int value) {
+    Config.max_additional_delay = value * 1000;
+  });
+  input->onConfirm([](int) {
+    saveConfigToSd(0);
+  });
+});
+
 UIInput MinimumOnTimeInput("Minimum On Time", [](UIMenu *ip) {
   UIInput *input = (UIInput*) ip;
   input->setMax(5000);
@@ -116,6 +129,7 @@ static void buildMenu(UIMenu *menu) {
   menu->addItem(&MotorStartSpeedInput);
   menu->addItem(&MotorRampTimeInput);
   menu->addItem(&EdgeDelayInput);
+  menu->addItem(&MaxAdditionalDelayInput);
   menu->addItem(&MinimumOnTimeInput);
   menu->addItem(&ArousalLimitInput);
   menu->addItem(&SensorSensitivityInput);


### PR DESCRIPTION
A neat feature I thought up while looking at your product. Sometimes the ability to have a random delay and not knowing when it will start is half the fun.

Since I do not own a device, I was unable to test this code. Feel free to adapt as necessary.