### PR TITLE
Muscle clench detector and/or Ruined Orgasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-# Fork of 0.3.4
-Adding a clench detector on the orgasm detection routines to permit an other type of orgasm detection.
-
-if tuned high level it will trigger a failed orgasm.
-if tuned low it adds to the already great code to detect incomming orgasm.
-
-
-
 # Edge-o-Matic 3000 - An Automated Orgasm Denial Device
 
 This code is an ESP32 rewrite of the core NoGasm project by Rhoboto: [github.com/nogasm/nogasm](https://github.com/nogasm/nogasm)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Fork of 0.3.4
+Adding a clench detector on the orgasm detection routines to permit an other type of orgasm detection.
+
+if tuned high level it will trigger a failed orgasm.
+if tuned low it adds to the already great code to detect incomming orgasm.
+
+
+
 # Edge-o-Matic 3000 - An Automated Orgasm Denial Device
 
 This code is an ESP32 rewrite of the core NoGasm project by Rhoboto: [github.com/nogasm/nogasm](https://github.com/nogasm/nogasm)

--- a/include/OrgasmControl.h
+++ b/include/OrgasmControl.h
@@ -59,6 +59,12 @@ namespace OrgasmControl {
     // File Writer
     long recording_start_ms = 0;
     File logfile;
+    
+    //  Clench variables
+	  long clench_pressure_threshold = 500; // setting start clench threshold to be over deflated plug
+	  int clench_duration = 0;
+    //	int clench_pressure_sensitivity = 200; //  placed in config.h
+    //	int clench_duration_threshold = 55;
 
     void updateArousal();
     void updateMotorSpeed();

--- a/include/OrgasmControl.h
+++ b/include/OrgasmControl.h
@@ -61,8 +61,8 @@ namespace OrgasmControl {
     File logfile;
     
     //  Clench variables
-	  long clench_pressure_threshold = 500; // setting start clench threshold to be over deflated plug
-	  int clench_duration = 0;
+    long clench_pressure_threshold = 500; // setting start clench threshold to be over deflated plug
+    int clench_duration = 0;
     //	int clench_pressure_sensitivity = 200; //  placed in config.h
     //	int clench_duration_threshold = 55;
 

--- a/include/config.h
+++ b/include/config.h
@@ -113,6 +113,10 @@ struct ConfigStruct {
 
   // Vibration Output Mode
   VibrationMode vibration_mode;
+  
+  // clench stuff
+  int clench_pressure_sensitivity = 200;
+  int clench_duration_threshold = 55;
 } extern Config;
 
 extern void loadConfigFromSd();

--- a/src/OrgasmControl.cpp
+++ b/src/OrgasmControl.cpp
@@ -182,7 +182,9 @@ namespace OrgasmControl {
           String(getAveragePressure()) + "," +
           String(getArousal()) + "," +
           String(Hardware::getMotorSpeed()) + "," +
-          String(Config.sensitivity_threshold);
+          String(Config.sensitivity_threshold) + "," +
+	  String(clench_pressure_threshold) + "," +
+	  String(clench_duration);
 
       // Write out to logfile, which includes millis:
       if (logfile) {

--- a/src/OrgasmControl.cpp
+++ b/src/OrgasmControl.cpp
@@ -47,6 +47,30 @@ namespace OrgasmControl {
       }
 
       last_value = p_check;
+      
+      // detect muscle clenching.  (Can be used for ruined orgasm if tease threshold is set too high and clench duration threshold is also high)	
+      if (p_check >= (clench_pressure_threshold + Config.clench_pressure_sensitivity) ) {
+        clench_pressure_threshold = (p_check - (Config.clench_pressure_sensitivity/2)); // raise clench threshold to pressure - 1/2 sensitivity
+      }
+	    if (p_check >= clench_pressure_threshold) {
+        clench_duration += 1;   // Start counting clench time if pressure over threshold
+		    if ( clench_duration > Config.clench_duration_threshold) {
+			    arousal *= 1.1;     // boost arousal  because clench duration exceeded 
+			    if ( arousal > 4095 ) { arousal = 4096; } // protect arousal value to not go higher then 4096
+		    }
+  		  if ( clench_duration >= (Config.clench_duration_threshold*2) ) { // desensitize clench threshold when clench too long. this is to stop arousal from going up
+			    clench_pressure_threshold += 400;
+			    clench_duration = 0;
+		    }
+	    } else {                     // when not clenching lower clench time and decay clench threshold
+		    clench_duration -= 5;
+		    if ( clench_duration <=0 ) {
+			    clench_duration = 0;
+			    if ( (p_check + (Config.clench_pressure_sensitivity/2)) < clench_pressure_threshold ){  // clench pressure threshold value decays over time to a min of pressure + 1/2 sensitivity
+				    clench_pressure_threshold -= 1;
+			    }
+		    }
+	    } // end of clenching detection
     }
 
     void updateMotorSpeed() {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -103,6 +103,10 @@ void loadConfigFromJsonObject(JsonDocument &doc) {
 
   // Copy Vibration Settings
   Config.vibration_mode = (VibrationMode)(doc["vibration_mode"] | (int)VibrationMode::RampStop);
+  
+  // Clench settings
+  Config.clench_pressure_sensitivity = doc["clench_pressure_sensitivity"] | 200;
+  Config.clench_duration_threshold = doc["clench_duration_threshold"] | 55;
 
   /**
    * Setting Validations
@@ -150,6 +154,10 @@ void dumpConfigToJsonObject(JsonDocument &doc) {
 
   // Vibration Settings
   doc["vibration_mode"] = (int) Config.vibration_mode;
+  
+  // Clench settings
+  doc["clench_pressure_sensitivity"] = Config.clench_pressure_sensitivity;
+  doc["clench_duration_threshold"] = Config.clench_duration_threshold;
 } // dumpConfigToJsonObject
 
 bool dumpConfigToJson(String &str) {
@@ -267,6 +275,10 @@ bool setConfigValue(const char *option, const char *value, bool &require_reboot)
     require_reboot = true;
   } else if (!strcmp(option, "vibration_mode")) {
     Config.vibration_mode = (VibrationMode) atoi(value);
+  } else if(!strcmp(option, "clench_pressure_sensitivity")) {
+    Config.clench_pressure_sensitivity = atoi(value);
+  } else if(!strcmp(option, "clench_duration_threshold")) {
+    Config.clench_duration_threshold = atoi(value);
   } else {
     return false;
   }
@@ -323,6 +335,10 @@ bool getConfigValue(const char *option, String &out) {
     out += String(Config.hostname) + '\n';
   } else if (!strcmp(option, "vibration_mode")) {
     out += String((int) Config.vibration_mode) + '\n';
+  } else if(!strcmp(option, "clench_pressure_sensitivity")) { 
+    out += String(Config.clench_pressure_sensitivity) + '\n';
+  } else if(!strcmp(option, "clench_duration_threshold")) {
+    out += String(Config.clench_duration_threshold) + '\n';
   } else {
     return false;
   }

--- a/src/menus/EdgingSettingsMenu.cpp
+++ b/src/menus/EdgingSettingsMenu.cpp
@@ -111,6 +111,32 @@ UIInput SensorSensitivityInput("Sensor Sensitivity", [](UIMenu *ip) {
   });
 });
 
+UIInput ClenchPressureSensitivity("Clench Pressure Sensitivity", [](UIMenu *ip) {
+  UIInput *input = (UIInput*) ip;
+  input->setMax(300);
+  input->setStep(1);
+  input->setValue(Config.clench_pressure_sensitivity);
+  input->onChange([](int value) {
+    Config.clench_pressure_sensitivity = value;
+  });
+  input->onConfirm([](int) {
+    saveConfigToSd(0);
+  });
+});
+
+UIInput ClenchTimeThreshold("Clench Time Threshold", [](UIMenu *ip) {
+  UIInput *input = (UIInput*) ip;
+  input->setMax(300);
+  input->setStep(1);
+  input->setValue(Config.clench_duration_threshold);
+  input->onChange([](int value) {
+    Config.clench_duration_threshold = value;
+  });
+  input->onConfirm([](int) {
+    saveConfigToSd(0);
+  });
+});
+
 static void setVibrateMode(UIMenu *menu, int m) {
   VibrationMode mode = (VibrationMode) m;
 
@@ -161,6 +187,8 @@ static void buildMenu(UIMenu *menu) {
   menu->addItem(&MinimumOnTimeInput);
   menu->addItem(&ArousalLimitInput);
   menu->addItem(&SensorSensitivityInput);
+  menu->addItem(&ClenchPressureSensitivity); //  Clench Menu
+  menu->addItem(&ClenchTimeThreshold);       //  Clench Menu
 }
 
 UIMenu EdgingSettingsMenu("Edging Settings", &buildMenu);


### PR DESCRIPTION
Hi, I've added a clench detector that adds to your edge detector to help in adding more chance to detect a edge of orgasm,

this same clench detector if you set the clench time threshold high enough with a high edge threshold can be used to detect a real orgasm and trigger a ruined orgasm.

you can directly test my Main branch on your Edge-o-matic 3000

My personnal branch is to compile on my test board of your edge-o-matic, it has different pinouts


