### PR TITLE
Setup CI using GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+name: Build
+on: [ push, pull_request ]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+        
+    - name: Write Version Info
+      shell: bash
+      run: |
+        echo '#define VERSION "'$(git rev-parse --short HEAD)'"' > include/VERSION.h
+
+    - name: Run PlatformIO
+      run: pio run
+      
+    - name: Rename Firmware
+      run: cp .pio/build/esp32dev/firmware.bin update.bin
+      
+    - name: Upload Firmware
+      uses: actions/upload-artifact@v2
+      with:
+        path: update.bin
+        if-no-files-found: error

--- a/include/BluetoothServer.h
+++ b/include/BluetoothServer.h
@@ -1,7 +1,6 @@
 #ifndef __BluetoothServer_h
 #define __BluetoothServer_h
 
-#include <arduino.h>
 #include "config.h"
 
 #include <NimBLEDevice.h>

--- a/include/Hardware.h
+++ b/include/Hardware.h
@@ -1,7 +1,6 @@
 #ifndef __Hardware_h
 #define __Hardware_h
 
-#include "arduino.h"
 #include "config.h"
 
 #include "UserInterface.h"

--- a/include/Icons.h
+++ b/include/Icons.h
@@ -1,7 +1,7 @@
 #ifndef __Icons_h
 #define __Icons_h
 
-#include <arduino.h>
+#include <pgmspace.h>
 
 byte WIFI_ICON[6][8] PROGMEM = {
     {

--- a/include/assets.h
+++ b/include/assets.h
@@ -1,6 +1,6 @@
 #ifndef __ASSETS_h
 #define __ASSETS_h
-#include "arduino.h"
+#include <pgmspace.h>
 
 extern unsigned char SPLASH_IMG[] PROGMEM;
 extern unsigned char PLUG_ICON[][24*3] PROGMEM;

--- a/include/config.h
+++ b/include/config.h
@@ -1,7 +1,6 @@
 #ifndef __config_h
 #define __config_h
 
-#include "arduino.h"
 #include "errors.h"
 #include "VibrationModeController.h"
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -10,7 +10,7 @@
 #include "Hardware.h"
 #include "Page.h"
 
-#include <FastLed.h>
+#include <FastLED.h>
 
 ConfigStruct Config;
 


### PR DESCRIPTION
There are two commits here, the first commit fixes building using only the PlatformIO tools on Linux with no separate Arduino SDK in the include path, and the 2nd using the PlatformIO CLI to build a firmware image. I've tested the build on Windows as well to make sure it's still good there, but it didn't seem worthwhile to include multiple in the CI run as it is cross-compilation anyway.

I haven't tested the firmware image on any hardware yet, as I've only got the one and wouldn't want to take any risks - as this build process (and the HAL lib linked) appears to be a very recent undertaking.