### PR TITLE
[WIP] Make orgasm detection work in manual mode, and output status with readings.

### DIFF
--- a/include/OrgasmControl.h
+++ b/include/OrgasmControl.h
@@ -24,6 +24,7 @@ namespace OrgasmControl {
   void controlMotor(bool control = true);
   void pauseControl();
   void resumeControl();
+  void resetOrgasm();
 
   // Recording Control
   void startRecording();
@@ -37,6 +38,7 @@ namespace OrgasmControl {
   bool isMenuLocked();
   bool isPermitOrgasmReached();
   bool isPostOrgasmReached();
+  bool isOrgasmDetected();
   void permitOrgasmNow(int seconds);
   void lockMenuNow(bool value);
 

--- a/src/OrgasmControl.cpp
+++ b/src/OrgasmControl.cpp
@@ -62,7 +62,7 @@ namespace OrgasmControl {
         clench_duration += 1;
   
         // Orgasm detected
-        if ( clench_duration >= Config.clench_threshold_2_orgasm && isPermitOrgasmReached()) { 
+        if ( clench_duration >= Config.clench_threshold_2_orgasm && (RunGraphPage.getMode() == 0 || isPermitOrgasmReached())) {
           detected_orgasm = true;
           clench_duration = 0;
         }
@@ -202,7 +202,7 @@ namespace OrgasmControl {
             Hardware::setMotorSpeed(motor_speed);
           } else {
             menu_is_locked = false;
-            detected_orgasm = false;
+            resetOrgasm();
             motor_speed = 0;
             Hardware::setMotorSpeed(motor_speed);
             RunGraphPage.setMode("manual");
@@ -352,8 +352,12 @@ namespace OrgasmControl {
     control_motor = prev_control_motor;
   }
 
-  void permitOrgasmNow(int seconds) {
+  void resetOrgasm() {
     detected_orgasm = false;
+  }
+
+  void permitOrgasmNow(int seconds) {
+    resetOrgasm();
     RunGraphPage.setMode("postorgasm");
     auto_edging_start_millis = millis() - (Config.auto_edging_duration_minutes * 60 * 1000);
     post_orgasm_duration_seconds = seconds;
@@ -366,6 +370,10 @@ namespace OrgasmControl {
     } else {
       return false;
     }
+  }
+
+  bool isOrgasmDetected() {
+    return detected_orgasm;
   }
 
   bool isPostOrgasmReached() {

--- a/src/WebSocketHelper.cpp
+++ b/src/WebSocketHelper.cpp
@@ -187,6 +187,7 @@ namespace WebSocketHelper {
     doc["runMode"] = mode;
     doc["permitOrgasm"] = OrgasmControl::isPermitOrgasmReached();
     doc["postOrgrasm"] = OrgasmControl::isPostOrgasmReached();
+    doc["orgasmDetected"] = OrgasmControl::isOrgasmDetected();
     doc["lock"] = OrgasmControl::isMenuLocked();
     //    doc["screenshot"] = screenshot;
 

--- a/src/pages/pRunGraph.h
+++ b/src/pages/pRunGraph.h
@@ -170,6 +170,7 @@ class pRunGraph : public Page {
         mode = Manual;
         Hardware::setMotorSpeed(0);
         OrgasmControl::controlMotor(false);
+        OrgasmControl::resetOrgasm();
         break;
       case 2:
         if (OrgasmControl::isMenuLocked()) {
@@ -185,6 +186,7 @@ class pRunGraph : public Page {
           mode = Manual;
           OrgasmControl::controlMotor(false);
         }
+        OrgasmControl::resetOrgasm();
         break;
     }
 
@@ -221,6 +223,7 @@ public:
       mode = PostOrgasm;
       OrgasmControl::controlMotor(true);
     }
+    OrgasmControl::resetOrgasm();
 
     updateButtons();
   }


### PR DESCRIPTION
In edging+orgasm mode, it's possible for an application connected to the WebSocket interface to infer orgasm from change of status, but since manual mode doesn't try to detect it, this is more difficult. The idea of this change is to make the device do this detection in manual mode, and to make the status visible externally, so that an application connected to the device can control the vibrator in its own way while benefiting from the device doing detection.

I haven't been able to test how well this actually works, in particular if there is a problem with false positives. FWIW, I made it reset the status any time the mode is set, so an application can make use of that as necessary.