### PR TITLE
config mutex

### DIFF
--- a/include/config_defs.h
+++ b/include/config_defs.h
@@ -204,7 +204,7 @@ typedef enum migration_result {
 bool atob(const char* a);
 esp_err_t config_init(void);
 void config_serialize(config_t* cfg, char* buf, size_t buflen);
-void config_deserialize(config_t* cfg, const char* buf);
+esp_err_t config_deserialize(config_t* cfg, const char* buf);
 esp_err_t config_load_from_sd(const char* filename, config_t* cfg);
 esp_err_t config_save_to_sd(const char* filename, config_t* cfg);
 void config_load_default(config_t* cfg);

--- a/include/config_defs.h
+++ b/include/config_defs.h
@@ -82,6 +82,10 @@ typedef enum migration_result {
                 if (in_val != NULL) strlcpy(cfg->name, in_val, sizeof(cfg->name));                 \
                 return true;                                                                       \
             }                                                                                      \
+        } else {                                                                                   \
+            if (operation == CFG_SET) {                                                            \
+                strlcpy(cfg->name, default, sizeof(cfg->name));                                    \
+            }                                                                                      \
         }                                                                                          \
     }
 
@@ -93,7 +97,10 @@ typedef enum migration_result {
                 if (item != NULL || operation == CFG_SET) {                                        \
                     /* intentional cstring pointer comparison */                                   \
                     if (cfg->name != default) free(cfg->name);                                     \
-                    asiprintf(&cfg->name, "%s", item == NULL ? default : item->valuestring);       \
+                    if (item == NULL)                                                              \
+                        cfg->name = default;                                                       \
+                    else                                                                           \
+                        asiprintf(&cfg->name, "%s", item->valuestring);                            \
                 }                                                                                  \
             } else {                                                                               \
                 cJSON_AddStringToObject(root, #name, cfg->name);                                   \
@@ -109,6 +116,11 @@ typedef enum migration_result {
                     asiprintf(&cfg->name, "%s", in_val);                                           \
                 }                                                                                  \
                 return true;                                                                       \
+            }                                                                                      \
+        } else {                                                                                   \
+            if (operation == CFG_SET) {                                                            \
+                if (cfg->name != default) free(cfg->name);                                         \
+                cfg->name = default;                                                               \
             }                                                                                      \
         }                                                                                          \
     }
@@ -132,6 +144,10 @@ typedef enum migration_result {
                 if (in_val != NULL) cfg->name = atoi(in_val);                                      \
                 return true;                                                                       \
             }                                                                                      \
+        } else {                                                                                   \
+            if (operation == CFG_SET) {                                                            \
+                cfg->name = default;                                                               \
+            }                                                                                      \
         }                                                                                          \
     }
 
@@ -153,6 +169,10 @@ typedef enum migration_result {
                 if (in_val != NULL) cfg->name = (type)atoi(in_val);                                \
                 return true;                                                                       \
             }                                                                                      \
+        } else {                                                                                   \
+            if (operation == CFG_SET) {                                                            \
+                cfg->name = default;                                                               \
+            }                                                                                      \
         }                                                                                          \
     }
 
@@ -173,6 +193,10 @@ typedef enum migration_result {
             } else {                                                                               \
                 if (in_val != NULL) cfg->name = atob(in_val);                                      \
                 return true;                                                                       \
+            }                                                                                      \
+        } else {                                                                                   \
+            if (operation == CFG_SET) {                                                            \
+                cfg->name = default;                                                               \
             }                                                                                      \
         }                                                                                          \
     }

--- a/include/console.h
+++ b/include/console.h
@@ -9,6 +9,10 @@ extern "C" {
 #include <stdio.h>
 #include <string.h>
 
+#define PROMPT "eom:%s> "
+#define ARGV_MAX 16
+#define CMDLINE_MAX 256
+
 enum command_err {
     CMD_FAIL = -1,
     CMD_OK = 0,

--- a/src/config.c
+++ b/src/config.c
@@ -1,6 +1,9 @@
 #include "config.h"
 #include "config_defs.h"
+#include "esp_log.h"
 #include <string.h>
+
+static const char* TAG = "config";
 
 config_t Config = { ._filename = "", ._version = 0 };
 

--- a/src/orgasm_control.c
+++ b/src/orgasm_control.c
@@ -152,7 +152,8 @@ static void orgasm_control_updateArousal() {
 
     // Start counting clench time if pressure over threshold
     if (p_check >= post_orgasm_state.clench_pressure_threshold) {
-        post_orgasm_state.clench_duration_millis = current_time - post_orgasm_state.clench_start_millis;
+        post_orgasm_state.clench_duration_millis =
+            current_time - post_orgasm_state.clench_start_millis;
 
         // Orgasm detected
         if (post_orgasm_state.clench_duration_millis >= Config.clench_time_to_orgasm_ms &&
@@ -171,17 +172,21 @@ static void orgasm_control_updateArousal() {
 
         // desensitize clench threshold when clench too long. this is to stop arousal from going up
         if (post_orgasm_state.clench_duration_millis >= Config.max_clench_duration_ms &&
-            !orgasm_control_isPermitOrgasmReached()) { // Allow higher clench duration when orgasm permitted
+            !orgasm_control_isPermitOrgasmReached(
+            )) { // Allow higher clench duration when orgasm permitted
             post_orgasm_state.clench_pressure_threshold += 10;
-//            post_orgasm_state.clench_pressure_threshold += 100000; // desensitize enough to reduce clench cheating
-            post_orgasm_state.clench_duration_millis = Config.max_clench_duration_ms; //ms
+            //            post_orgasm_state.clench_pressure_threshold += 100000; // desensitize
+            //            enough to reduce clench cheating
+            post_orgasm_state.clench_duration_millis = Config.max_clench_duration_ms; // ms
         }
 
         // when not clenching lower clench time and decay clench threshold
     } else {
-        if (output_state.motor_speed > 0 || output_state.output_mode == OC_MANUAL_CONTROL ){  // decay only in Manual mode or if not in a denial period
+        if (output_state.motor_speed > 0 ||
+            output_state.output_mode ==
+                OC_MANUAL_CONTROL) { // decay only in Manual mode or if not in a denial period
             post_orgasm_state.clench_start_millis = current_time;
-            post_orgasm_state.clench_duration_millis -= 150; //ms
+            post_orgasm_state.clench_duration_millis -= 150; // ms
 
             if (post_orgasm_state.clench_duration_millis <= 0) {
                 post_orgasm_state.clench_duration_millis = 0;
@@ -430,6 +435,8 @@ oc_bool_t orgasm_control_isRecording() {
 }
 
 void orgasm_control_tick() {
+    if (Config.update_frequency_hz == 0) return;
+
     unsigned long millis = esp_timer_get_time() / 1000UL;
     unsigned long update_frequency_ms = 1000UL / Config.update_frequency_hz;
 
@@ -503,6 +510,7 @@ uint16_t orgasm_control_getArousal() {
 }
 
 float orgasm_control_getArousalPercent() {
+    if (Config.sensitivity_threshold == 0) return 1.0;
     return (float)arousal_state.arousal / Config.sensitivity_threshold;
 }
 

--- a/src/vibration_modes/depletion_controller.c
+++ b/src/vibration_modes/depletion_controller.c
@@ -17,6 +17,8 @@ static float start(void) {
 }
 
 static float increment(void) {
+    if (Config.sensitivity_threshold == 0) return 0.0;
+
     if (state.base_speed < Config.motor_max_speed) {
         state.base_speed += calculate_increment(
             Config.motor_start_speed, Config.motor_max_speed, Config.motor_ramp_time_s

--- a/src/vibration_modes/enhancement_controller.c
+++ b/src/vibration_modes/enhancement_controller.c
@@ -11,9 +11,13 @@ static struct {
     oc_bool_t stopped;
 } state;
 
-static float start(void) { return Config.motor_start_speed; }
+static float start(void) {
+    return Config.motor_start_speed;
+}
 
 static float increment(void) {
+    if (Config.sensitivity_threshold == 0) return 1.0;
+
     if (state.stopped) {
         return state.motor_speed +
                calculate_increment(Config.motor_max_speed, 0, Config.edge_delay);


### PR DESCRIPTION
- Add a file mutex to configuration to prevent simultaneous writes.
- Load default values in the event that config file was unable to parse into a valid root.
- Add some utilities to the console to facilitate file read/write.
- Inform user of corrupt config file. Also, do not rely on config values in division.
