### PR TITLE
Remove mode LOCKOUT_POST_MODE

### DIFF
--- a/include/orgasm_control.h
+++ b/include/orgasm_control.h
@@ -15,7 +15,6 @@ typedef enum orgasm_output_mode {
     OC_MANUAL_CONTROL,
     OC_AUTOMAITC_CONTROL,
     OC_ORGASM_MODE,
-    OC_LOCKOUT_POST_MODE,
     _OC_MODE_MAX,
     _OC_MODE_ERROR = -1
 } orgasm_output_mode_t;

--- a/src/orgasm_control.c
+++ b/src/orgasm_control.c
@@ -21,7 +21,6 @@ static const char* orgasm_output_mode_str[] = {
     "MANUAL_CONTROL",
     "AUTOMAITC_CONTROL",
     "ORGASM_MODE",
-    "LOCKOUT_POST_MODE",
 };
 
 static struct {


### PR DESCRIPTION
This mode is settable via the WebSocket UI but doesn't do anything any more.

Fixes #67.