### PR TITLE
Fix motor and accessory control when orgasm is permitted or in post o…

### DIFF
--- a/src/orgasm_control.c
+++ b/src/orgasm_control.c
@@ -343,8 +343,12 @@ static void orgasm_control_updateEdgingTime() { // Edging+Orgasm timer
             }
         }
     }
-
-    eom_hal_set_motor_speed(orgasm_control_getMotorSpeed());
+    if (orgasm_control_isPermitOrgasmReached() || orgasm_control_isPostOrgasmReached()) {
+        uint8_t speed = orgasm_control_getMotorSpeed();
+        eom_hal_set_motor_speed(speed);
+        accessory_driver_broadcast_speed(speed);
+        bluetooth_driver_broadcast_speed(speed);
+    }
 }
 
 void orgasm_control_twitchDetect() {


### PR DESCRIPTION
I noticed that the mercury-1000 does not get speed control when entering the permit orgasm and post orgasm phases.

this patches the problem.

this also fixes bluetooth  control