### PR TITLE
Organize orgasm menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and is automatically generated. Here is a quick summary of config variables:
 |`sensor_sensitivity`|Byte|128|Analog pressure prescaling. Please see instruction manual.|
 |`use_average_values`|Boolean|false|Use average values when calculating arousal. This smooths noisy data.|
 |`vibration_mode`|VibrationMode|RampStop|Vibration Mode for main vibrator control.|
-|`use_post_orgasm`|Boolean|false|Use post-orgasm torture mode and functionality.|
+|`use_orgasm_modes`|Boolean|false|Use orgasm and post-orgasm torture modes and functionality.|
 |`clench_pressure_sensitivity`|Int|200|Minimum additional Arousal level to detect clench. See manual.|
 |`clench_time_to_orgasm_ms`|Int|1500|Threshold variable that is milliseconds count of clench to detect orgasm. See manual.|
 |`clench_detector_in_edging`|Boolean|false|Use the clench detector to adjust Arousal. See manual.|

--- a/include/assets/config_help.h
+++ b/include/assets/config_help.h
@@ -47,7 +47,7 @@ extern "C" {
 #define SENSOR_SENSITIVITY_HELP _HELPSTR("Analog pressure prescaling. Please see instruction manual.")
 #define USE_AVERAGE_VALUES_HELP _HELPSTR("Use average values when calculating arousal. This smooths noisy data.")
 #define VIBRATION_MODE_HELP _HELPSTR("Vibration Mode for main vibrator control.")
-#define USE_POST_ORGASM_HELP _HELPSTR("Use post-orgasm torture mode and functionality.")
+#define USE_ORGASM_MODES_HELP _HELPSTR("Use orgasm and post-orgasm torture modes and functionality.")
 #define CLENCH_PRESSURE_SENSITIVITY_HELP _HELPSTR("Minimum additional Arousal level to detect clench. See manual.")
 #define CLENCH_TIME_TO_ORGASM_MS_HELP _HELPSTR("Threshold variable that is milliseconds count of clench to detect orgasm. See manual.")
 #define CLENCH_DETECTOR_IN_EDGING_HELP _HELPSTR("Use the clench detector to adjust Arousal. See manual.")

--- a/include/config.h
+++ b/include/config.h
@@ -129,8 +129,8 @@ struct config {
 
     //= Post orgasm torure stuff
 
-    // Use post-orgasm torture mode and functionality.
-    bool use_post_orgasm;
+    // Use orgasm and post-orgasm torture mode and functionality.
+    bool use_orgasm_modes;
     // Threshold over arousal to detect a clench : Lower values increase sensitivity
     int clench_pressure_sensitivity;
     // Duration the clench detector can raise arousal if clench detector turned on in edging session

--- a/src/config.c
+++ b/src/config.c
@@ -53,7 +53,7 @@ CONFIG_DEFS {
     CFG_ENUM(vibration_mode, vibration_mode_t, RampStop);
 
     // Post-Orgasm Torture
-    CFG_BOOL(use_post_orgasm, false);
+    CFG_BOOL(use_orgasm_modes, false);
     CFG_NUMBER(clench_pressure_sensitivity, 200);
     CFG_NUMBER(clench_time_to_orgasm_ms, 1500);
     CFG_NUMBER(clench_time_threshold_ms, 900);

--- a/src/config/system/migrate.c
+++ b/src/config/system/migrate.c
@@ -54,10 +54,10 @@ migration_result_t migrate_to_3(cJSON* root) {
 
     // migrate old value
     if (cJSON_IsTrue(old) == 0) {
-        cJSON* new = cJSON_AddBoolToObject(root,"use_orgasm_modes", true);
+        cJSON* new = cJSON_AddBoolToObject(root,"use_orgasm_modes", false);
         if (new == NULL) return MIGRATION_ERR_BAD_DATA;
     } else {
-        cJSON* new = cJSON_AddBoolToObject(root,"use_orgasm_modes", false);
+        cJSON* new = cJSON_AddBoolToObject(root,"use_orgasm_modes", true);
         if (new == NULL) return MIGRATION_ERR_BAD_DATA;
     }
 

--- a/src/config/system/migrate.c
+++ b/src/config/system/migrate.c
@@ -45,12 +45,35 @@ migration_result_t migrate_to_2(cJSON* root) {
     return MIGRATION_COMPLETE;
 }
 
+/**
+ * Rename "use_post_orgasm" to "use_orgasm_modes"
+ */
+migration_result_t migrate_to_3(cJSON* root) {
+    cJSON* old  = cJSON_GetObjectItemCaseSensitive(root, "use_post_orgasm");
+    if (old == NULL) return MIGRATION_COMPLETE;
+
+    // migrate old value
+    if (cJSON_IsTrue(old) == 0) {
+        cJSON* new = cJSON_AddBoolToObject(root,"use_orgasm_modes", true);
+        if (new == NULL) return MIGRATION_ERR_BAD_DATA;
+    } else {
+        cJSON* new = cJSON_AddBoolToObject(root,"use_orgasm_modes", false);
+        if (new == NULL) return MIGRATION_ERR_BAD_DATA;
+    }
+
+    cJSON_DeleteItemFromObject(root, "use_post_orgasm");
+    cJSON_Delete(root);
+
+    return MIGRATION_COMPLETE;
+}
+
 migration_result_t config_system_migrate(cJSON* root) {
     START_MIGRATION();
 
     // List all migration calls below, in numeric order:
     MIGRATE(1);
     MIGRATE(2);
+    MIGRATE(3);
 
     END_MIGRATION();
 }

--- a/src/menus/orgasm_settings_menu.c
+++ b/src/menus/orgasm_settings_menu.c
@@ -31,9 +31,9 @@ static const ui_input_numeric_t POST_ORGASM_DURATION_SECONDS_INPUT = {
     .input.help = POST_ORGASM_DURATION_SECONDS_HELP
 };
 
-static const ui_input_toggle_t USE_POST_ORGASM_INPUT = {
-    ToggleInputValues("Use Post Orgasm Mode", &Config.use_post_orgasm, on_config_save),
-    .input.help = USE_POST_ORGASM_HELP
+static const ui_input_toggle_t USE_ORGASM_MODES_INPUT = {
+    ToggleInputValues("Enable Orgasm Modes", &Config.use_orgasm_modes, on_config_save),
+    .input.help = USE_ORGASM_MODES_HELP
 };
 
 static const ui_input_toggle_t EDGE_MENU_LOCK_INPUT = {
@@ -60,9 +60,9 @@ static const ui_input_numeric_t CLENCH_PRESSURE_SENSITIVITY_INPUT = {
 };
 
 static void on_open(const ui_menu_t* m, UI_MENU_ARG_TYPE arg) {
+    ui_menu_add_input(m, (ui_input_t*)&USE_ORGASM_MODES_INPUT);
     ui_menu_add_input(m, (ui_input_t*)&EDGING_DURATION_INPUT);
     ui_menu_add_input(m, (ui_input_t*)&CLENCH_TIME_TO_ORGASM_MS_INPUT);
-    ui_menu_add_input(m, (ui_input_t*)&USE_POST_ORGASM_INPUT);
     ui_menu_add_input(m, (ui_input_t*)&POST_ORGASM_DURATION_SECONDS_INPUT);
     ui_menu_add_input(m, (ui_input_t*)&EDGE_MENU_LOCK_INPUT);
     ui_menu_add_input(m, (ui_input_t*)&POST_ORGASM_MENU_LOCK_INPUT);

--- a/src/pages/edging_stats.c
+++ b/src/pages/edging_stats.c
@@ -86,7 +86,7 @@ static void _draw_buttons(u8g2_t* d, orgasm_output_mode_t mode) {
     } else if (mode == OC_MANUAL_CONTROL) {
         ui_draw_button_labels(d, btn1, btn2, _("AUTO"));
     } else if (mode == OC_AUTOMAITC_CONTROL) {
-        if (Config.use_post_orgasm == true) {
+        if (Config.use_orgasm_modes == true) {
             ui_draw_button_labels(d, btn1, btn2, _("POST"));
         } else {
             ui_draw_button_labels(d, btn1, btn2, _("MANUAL"));
@@ -291,7 +291,7 @@ on_button(eom_hal_button_t button, eom_hal_button_event_t event, void* arg) {
         if (mode == OC_MANUAL_CONTROL) {
             orgasm_control_set_output_mode(OC_AUTOMAITC_CONTROL);
         } else if (mode == OC_AUTOMAITC_CONTROL) {
-            if (Config.use_post_orgasm == true) {
+            if (Config.use_orgasm_modes == true) {
                 orgasm_control_set_output_mode(OC_ORGASM_MODE);
             } else {
                 orgasm_control_set_output_mode(OC_MANUAL_CONTROL);


### PR DESCRIPTION
This is to better organize the orgasm menu. Placing the "Enable orgasm modes" at the top of the menu. 

I renamed the variable from use_post_orgasm to use_orgasm_modes which is a better name for the functions that a activated